### PR TITLE
Binary function call

### DIFF
--- a/src/expression/deep.rs
+++ b/src/expression/deep.rs
@@ -278,7 +278,14 @@ mod detail {
         while idx_tkn < parsed_tokens.len() {
             match &parsed_tokens[idx_tkn] {
                 ParsedToken::Op(op) => {
-                    if idx_tkn > 0 && parser::is_operator_binary(op, &parsed_tokens[idx_tkn - 1])? {
+                    if parser::is_operator_binary(
+                        op,
+                        if idx_tkn == 0 {
+                            None
+                        } else {
+                            Some(&parsed_tokens[idx_tkn - 1])
+                        },
+                    )? {
                         bin_ops.push(op.bin()?);
                         reprs_bin_ops.push(op.repr());
                         idx_tkn += 1;

--- a/src/expression/flat.rs
+++ b/src/expression/flat.rs
@@ -381,14 +381,14 @@ mod detail {
     where
         T: DataType,
     {
-        Ok(parser::is_operator_binary(
+        parser::is_operator_binary(
             op,
             if idx > 0 {
                 Some(&parsed_tokens[idx - 1])
             } else {
                 None
             },
-        )?)
+        )
     }
 
     type ExResultOption<T> = ExResult<Option<T>>;

--- a/src/expression/flat.rs
+++ b/src/expression/flat.rs
@@ -381,7 +381,14 @@ mod detail {
     where
         T: DataType,
     {
-        Ok(idx > 0 && parser::is_operator_binary(op, &parsed_tokens[idx - 1])?)
+        Ok(parser::is_operator_binary(
+            op,
+            if idx > 0 {
+                Some(&parsed_tokens[idx - 1])
+            } else {
+                None
+            },
+        )?)
     }
 
     type ExResultOption<T> = ExResult<Option<T>>;
@@ -467,7 +474,7 @@ mod detail {
                         match p {
                             Paren::Close => {
                                 let err_msg =
-                                    "a unary operator cannot on the left of a closing paren";
+                                    "a unary operator cannot on the left of a closing paren or comma";
                                 return Err(ExError::new(err_msg));
                             }
                             Paren::Open => unary_stack.push((idx_tkn, depth)),
@@ -531,6 +538,15 @@ mod detail {
                     }
                 }
             }
+        }
+        let n_ops = flat_ops.len();
+        let n_nodes = flat_nodes.len();
+        if n_ops + 1 != n_nodes {
+            Err(exerr!(
+                "we have {} ops and {} node. we always need one more node than op.",
+                n_ops,
+                n_nodes
+            ))?
         }
         let indices = prioritized_indices_flat(&flat_ops, &flat_nodes);
         Ok(FlatEx {

--- a/src/operators.rs
+++ b/src/operators.rs
@@ -351,6 +351,14 @@ impl<T: Debug + Float> MakeOperators<T> for FloatOpsFactory<T> {
                 },
                 |a| -a,
             ),
+            Operator::make_bin(
+                "atan2",
+                BinOp {
+                    apply: |y, x| y.atan2(x),
+                    prio: 3,
+                    is_commutative: false,
+                },
+            ),
             Operator::make_unary("abs", |a| a.abs()),
             Operator::make_unary("signum", |a| a.signum()),
             Operator::make_unary("sin", |a| a.sin()),

--- a/src/operators.rs
+++ b/src/operators.rs
@@ -355,7 +355,7 @@ impl<T: Debug + Float> MakeOperators<T> for FloatOpsFactory<T> {
                 "atan2",
                 BinOp {
                     apply: |y, x| y.atan2(x),
-                    prio: 3,
+                    prio: 0,
                     is_commutative: false,
                 },
             ),

--- a/src/value.rs
+++ b/src/value.rs
@@ -694,10 +694,10 @@ where
             Operator::make_bin(
                 "else",
                 BinOp {
-                    apply: |res_of_if, v| match res_of_if {
+                    apply: |res_of_if, v| {println!("debug {res_of_if:?} {v:?}");match res_of_if {
                         Val::None => v,
                         _ => res_of_if,
-                    },
+                    }},
                     prio: 0,
                     is_commutative: false,
                 },

--- a/tests/core.rs
+++ b/tests/core.rs
@@ -981,7 +981,6 @@ fn test_binary_function_style() {
         println!("testing {s}");
         fn test_<'a, EX: Express<'a, f64> + Debug>(s: &'a str, vars: &[f64], reference: f64) {
             let expr = EX::parse(s).unwrap();
-            println!("{expr:?}");
             assert_float_eq_f64(expr.eval(vars).unwrap(), reference);
         }
         println!("flatex...");
@@ -989,13 +988,22 @@ fn test_binary_function_style() {
         println!("deepex...");
         test_::<DeepEx<f64>>(s, vars, reference);
     }
-    test("/ (1, -2)", &[], -0.5);
+    test(
+        "atan2(0.2/y, x)",
+        &[1.2, 2.1],
+        (0.2 / 2.1_f64).atan2(1.2_f64),
+    );
+    test("+ (1, -2) / 2", &[], -0.5);
     test("/ 1 2 * 3", &[], 1.5);
     test("atan2(1, 2) * 3", &[], 1.0f64.atan2(2.0) * 3.0);
-    test("atan2(1, x / 2) * 3", &[1.0], 1.0f64.atan2(0.5) * 3.0);
     test(
-        "atan2(0.2/y, x) * 3",
-        &[1.2, 2.1],
-        (0.2 / 2.1_f64).atan2(1.2_f64) * 3.0,
+        "2 + atan2(1, x / 2) * 3",
+        &[1.0],
+        2.0 + 1.0f64.atan2(0.5) * 3.0,
+    );
+    test(
+        "sin(atan2(1, x / 2)) * 3",
+        &[1.0],
+        (1.0f64.atan2(0.5)).sin() * 3.0,
     );
 }

--- a/tests/value.rs
+++ b/tests/value.rs
@@ -150,52 +150,89 @@ fn test_to() -> ExResult<()> {
     Ok(())
 }
 #[cfg(feature = "value")]
+#[cfg(test)]
+use exmex::{DeepEx, ValMatcher, ValOpsFactory};
+#[cfg(feature = "value")]
+#[cfg(test)]
+type Fx = FlatExVal<i32, f64>;
+#[cfg(feature = "value")]
+#[cfg(test)]
+type Dx<'a> = DeepEx<'a, Val<i32, f64>, ValOpsFactory<i32, f64>, ValMatcher>;
+#[cfg(feature = "value")]
 #[test]
 fn test_no_vars() -> ExResult<()> {
     fn test_int(s: &str, reference: i32) -> ExResult<()> {
-        println!("=== testing\n{}", s);
-        let res = exmex::parse_val::<i32, f64>(s)?.eval(&[])?.to_int();
-        match res {
-            Ok(i) => {
-                assert_eq!(reference, i);
+        fn test_<'a, EX>(s: &'a str, reference: i32) -> ExResult<()>
+        where
+            EX: Express<'a, Val<i32, f64>>,
+        {
+            println!("=== testing\n{}", s);
+            let res = exmex::parse_val::<i32, f64>(s)?.eval(&[])?.to_int();
+            match res {
+                Ok(i) => {
+                    assert_eq!(reference, i);
+                }
+                Err(e) => {
+                    println!("{:?}", e);
+                    unreachable!();
+                }
             }
-            Err(e) => {
-                println!("{:?}", e);
-                unreachable!();
-            }
+            Ok(())
         }
-        Ok(())
+        test_::<Fx>(s, reference)?;
+        test_::<Dx>(s, reference)
     }
     fn test_float(s: &str, reference: f64) -> ExResult<()> {
-        println!("=== testing\n{}", s);
-        let expr = FlatExVal::<i32, f64>::parse(s)?;
-        utils::assert_float_eq_f64(reference, expr.eval(&[])?.to_float()?);
-        Ok(())
+        fn test_<'a, EX>(s: &'a str, reference: f64) -> ExResult<()>
+        where
+            EX: Express<'a, Val<i32, f64>>,
+        {
+            println!("=== testing\n{}", s);
+            let expr = FlatExVal::<i32, f64>::parse(s)?;
+            utils::assert_float_eq_f64(reference, expr.eval(&[])?.to_float()?);
+            Ok(())
+        }
+        test_::<Fx>(s, reference)?;
+        test_::<Dx>(s, reference)
     }
     fn test_bool(s: &str, reference: bool) -> ExResult<()> {
         println!("=== testing\n{}", s);
-        let expr = FlatExVal::<i32, f64>::parse(s)?;
-        assert_eq!(reference, expr.eval(&[])?.to_bool()?);
-        Ok(())
+        fn test_<'a, EX>(s: &'a str, reference: bool) -> ExResult<()>
+        where
+            EX: Express<'a, Val<i32, f64>>,
+        {
+            let expr = EX::parse(s)?;
+            assert_eq!(reference, expr.eval(&[])?.to_bool()?);
+            Ok(())
+        }
+        test_::<Fx>(s, reference)?;
+        test_::<Dx>(s, reference)
     }
     fn test_error(s: &str) -> ExResult<()> {
-        let expr = FlatExVal::<i32, f64>::parse(s);
-        match expr {
-            Ok(exp) => {
-                let v = exp.eval(&[])?;
-                match v {
-                    Val::Error(e) => {
-                        println!("found expected error {:?}", e);
-                        Ok(())
+        fn test_<'a, EX>(s: &'a str) -> ExResult<()>
+        where
+            EX: Express<'a, Val<i32, f64>>,
+        {
+            let expr = EX::parse(s);
+            match expr {
+                Ok(exp) => {
+                    let v = exp.eval(&[])?;
+                    match v {
+                        Val::Error(e) => {
+                            println!("found expected error {:?}", e);
+                            Ok(())
+                        }
+                        _ => Err(exerr!("'{}' should fail but didn't", s)),
                     }
-                    _ => Err(exerr!("'{}' should fail but didn't", s)),
+                }
+                Err(e) => {
+                    println!("found expected error {:?}", e);
+                    Ok(())
                 }
             }
-            Err(e) => {
-                println!("found expected error {:?}", e);
-                Ok(())
-            }
         }
+        test_::<Fx>(&s)?;
+        test_::<Dx>(&s)
     }
     fn test_none(s: &str) -> ExResult<()> {
         let expr = FlatExVal::<i32, f64>::parse(s)?;
@@ -204,6 +241,7 @@ fn test_no_vars() -> ExResult<()> {
             _ => Err(exerr!("'{}' should return none but didn't", s)),
         }
     }
+    test_error("if true else 2")?;
     test_int("1+2 if 1 > 0 else 2+4", 3)?;
     test_int("1+2 if 1 < 0 else 2+4", 6)?;
     test_error("929<<92")?;
@@ -267,7 +305,6 @@ fn test_no_vars() -> ExResult<()> {
     test_bool("true == 1", false)?;
     test_bool("true else 2", true)?;
     test_int("1 else 2", 1)?;
-    test_error("if true else 2")?;
     test_none("2 if false")?;
     test_int("to_int(1)", 1)?;
     test_int("to_int(3.5)", 3)?;

--- a/tests/value.rs
+++ b/tests/value.rs
@@ -332,7 +332,7 @@ fn test_no_vars() -> ExResult<()> {
         "atanh(0.5)/asinh(-7.5)*acosh(2.3)",
         0.5f64.atanh() / (-7.5f64).asinh() * 2.3f64.acosh(),
     )?;
-
+    test_float("sin(atan2(1, 1.0 / 2.0))", (1.0f64.atan2(0.5)).sin())?;
     Ok(())
 }
 


### PR DESCRIPTION
Addresses issues #51 and #41 

All binary operators can be used either like `a op b` or like `op(a, b)`. Thereby, the latter will be interpreted as `((a) op (b))`. For instance
```
atan2(y * 2, 1 / x) * 2
```
and
```
((y * 2) atan2 (1 / x)) * 2
```
are equivalent. As a side-product, `atan2` has been added to the list of default-operators.
